### PR TITLE
Refactor File Storage for S3 support

### DIFF
--- a/internal/storage/files/binary_storage/bs.go
+++ b/internal/storage/files/binary_storage/bs.go
@@ -1,0 +1,3 @@
+// Package bs (Binary Storage) provides different ways to keep files
+package bs
+

--- a/internal/storage/files/binary_storage/bs_disk.go
+++ b/internal/storage/files/binary_storage/bs_disk.go
@@ -1,0 +1,116 @@
+package bs
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/minio/sio"
+	"github.com/pkg/errors"
+)
+
+type DiskStorage struct {
+	config DiskStorageConfig
+}
+
+type DiskStorageConfig struct {
+	DataFolder          string
+	ResizedImagesFolder string
+
+	Encrypt    bool
+	PassPhrase [32]byte
+}
+
+func NewDiskStorage(cnf DiskStorageConfig) (*DiskStorage, error) {
+	// Create folders
+	if err := os.MkdirAll(cnf.DataFolder, 0666); err != nil {
+		return nil, errors.Wrap(err, "can't create DataFolder")
+	}
+
+	if err := os.MkdirAll(cnf.ResizedImagesFolder, 0666); err != nil {
+		return nil, errors.Wrap(err, "can't create ResizedImagesFolder")
+	}
+
+	// Normalize paths
+	if !strings.HasSuffix(cnf.DataFolder, "/") {
+		cnf.DataFolder += "/"
+	}
+	if !strings.HasSuffix(cnf.ResizedImagesFolder, "/") {
+		cnf.ResizedImagesFolder += "/"
+	}
+
+	return &DiskStorage{
+		config: cnf,
+	}, nil
+}
+
+func (ds DiskStorage) GetFile(w io.Writer, fileID int, resized bool) error {
+	path := ds.getFilePath(fileID, resized)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.Wrapf(err, "can't open the file '%s'", path)
+	}
+	defer f.Close()
+
+	copier := io.Copy
+	if ds.config.Encrypt {
+		copier = func(dst io.Writer, src io.Reader) (int64, error) {
+			return sio.Decrypt(dst, src, sio.Config{Key: ds.config.PassPhrase[:]})
+		}
+	}
+
+	_, err = copier(w, f)
+	if err != nil {
+		return errors.Wrapf(err, "can't copy the file '%s' into io.Writer", path)
+	}
+
+	return nil
+}
+
+func (ds DiskStorage) GetFileStats(fileID int) (os.FileInfo, error) {
+	path := ds.getFilePath(fileID, false)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "can't open file '%s'", path)
+	}
+
+	// Can't use defer for file.Close()!
+	stats, err := f.Stat()
+	f.Close()
+	return stats, err
+}
+
+func (ds DiskStorage) SaveFile(r io.Reader, fileID int, resized bool) error {
+	path := ds.getFilePath(fileID, resized)
+
+	f, err := os.Create(path)
+	if err != nil {
+		return errors.Wrapf(err, "can't create a new file '%s'", path)
+	}
+	// TODO: delete file if an error occurred?
+	defer f.Close()
+
+	if ds.config.Encrypt {
+		_, err := sio.Encrypt(f, r, sio.Config{Key: ds.config.PassPhrase[:]})
+		return errors.Wrapf(err, "can't encrypt a file '%s'", err)
+	}
+
+	_, err = io.Copy(f, r)
+	return errors.Wrapf(err, "can't copy io.Reader into a file '%s'", err)
+}
+
+func (ds DiskStorage) DeleteFile(fileID int, resized bool) error {
+	path := ds.getFilePath(fileID, resized)
+	return os.Remove(path)
+}
+
+func (ds DiskStorage) getFilePath(id int, resized bool) string {
+	path := ds.config.DataFolder
+	if resized {
+		path = ds.config.ResizedImagesFolder
+	}
+	path += strconv.Itoa(id)
+	return path
+}

--- a/internal/storage/files/binary_storage/bs_disk_test.go
+++ b/internal/storage/files/binary_storage/bs_disk_test.go
@@ -1,0 +1,293 @@
+package bs_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/minio/sio"
+	"github.com/stretchr/testify/assert"
+
+	bs "github.com/tags-drive/core/internal/storage/files/binary_storage"
+)
+
+const (
+	testFolder          = "./test"
+	dataFolder          = "./test/data"
+	resizedImagesFolder = "./test/data/resized"
+)
+
+func TestDiskStorage_SaveFile(t *testing.T) {
+	t.Run("No encryption", func(t *testing.T) {
+		defer clear()
+
+		assert := assert.New(t)
+
+		cnf := bs.DiskStorageConfig{
+			DataFolder:          dataFolder,
+			ResizedImagesFolder: resizedImagesFolder,
+			Encrypt:             false,
+		}
+		storage, err := bs.NewDiskStorage(cnf)
+		if !assert.Nil(err) {
+			t.FailNow()
+		}
+
+		const buffSize = 4096
+		const id = 0
+
+		t.Run("Usual file", func(t *testing.T) {
+			original := generateRandomData(buffSize)
+			cp := make([]byte, buffSize)
+			copy(cp, original)
+
+			buff := bytes.NewBuffer(cp)
+			storage.SaveFile(buff, id, false)
+
+			path := dataFolder + "/" + strconv.Itoa(id)
+			assert.True(checkFile(path, original, false, nil), "files are not equal")
+		})
+
+		t.Run("Resized image", func(t *testing.T) {
+			original := generateRandomData(buffSize)
+			cp := make([]byte, buffSize)
+			copy(cp, original)
+
+			buff := bytes.NewBuffer(cp)
+			storage.SaveFile(buff, id, true)
+
+			path := resizedImagesFolder + "/" + strconv.Itoa(id)
+			assert.True(checkFile(path, original, false, nil), "files are not equal")
+		})
+	})
+
+	t.Run("With encryption", func(t *testing.T) {
+		defer clear()
+
+		assert := assert.New(t)
+
+		cnf := bs.DiskStorageConfig{
+			DataFolder:          dataFolder,
+			ResizedImagesFolder: resizedImagesFolder,
+			Encrypt:             true,
+			PassPhrase:          generatePassPhrase(),
+		}
+		storage, err := bs.NewDiskStorage(cnf)
+		if !assert.Nil(err) {
+			assert.FailNow("can't create a new DiskStorage")
+		}
+
+		const buffSize = 4096
+		const id = 1
+
+		t.Run("Usual file", func(t *testing.T) {
+			original := generateRandomData(buffSize)
+			cp := make([]byte, buffSize)
+			copy(cp, original)
+
+			buff := bytes.NewBuffer(cp)
+			storage.SaveFile(buff, id, false)
+
+			path := dataFolder + "/" + strconv.Itoa(id)
+			assert.True(checkFile(path, original, true, cnf.PassPhrase[:]), "files are not equal")
+		})
+
+		t.Run("Resized image", func(t *testing.T) {
+			original := generateRandomData(buffSize)
+			cp := make([]byte, buffSize)
+			copy(cp, original)
+
+			buff := bytes.NewBuffer(cp)
+			storage.SaveFile(buff, id, true)
+
+			path := resizedImagesFolder + "/" + strconv.Itoa(id)
+			assert.True(checkFile(path, original, true, cnf.PassPhrase[:]), "files are not equal")
+		})
+	})
+}
+
+func TestDiskStorage_GetFile(t *testing.T) {
+	// We can use this function for both tests because only DiskStorage configs differ
+	generateAndRunTests := func(assert *assert.Assertions, storage *bs.DiskStorage) {
+		tests := []struct {
+			id         int
+			resized    bool
+			data       []byte
+			fileExists bool
+		}{
+			// Files exist
+			{id: 0, resized: false, data: generateRandomData(512), fileExists: true},
+			{id: 0, resized: true, data: generateRandomData(128), fileExists: true},
+			// Files don't exist
+			{id: -1, resized: false, data: nil, fileExists: false},
+			{id: -1, resized: true, data: nil, fileExists: false},
+		}
+
+		// Create files
+		for i, tt := range tests {
+			if !tt.fileExists {
+				continue
+			}
+
+			cp := make([]byte, len(tt.data))
+			copy(cp, tt.data)
+
+			buff := bytes.NewBuffer(cp)
+			err := storage.SaveFile(buff, tt.id, tt.resized)
+			if !assert.Nilf(err, "Test #%d: can't create a file", i) {
+				assert.FailNow("can't create a file. Fail now")
+			}
+		}
+
+		for i, tt := range tests {
+			buff := &bytes.Buffer{}
+
+			err := storage.GetFile(buff, tt.id, tt.resized)
+			if tt.fileExists {
+				if !assert.Nilf(err, "Test #%d: can't get file", i) {
+					continue
+				}
+			} else {
+				if !assert.NotNilf(err, "Test #%d: get non-existed file", i) {
+					continue
+				}
+			}
+
+			// Check file
+			assert.Truef(bytes.Equal(tt.data, buff.Bytes()), "Test #%d: get wrong content", i)
+		}
+	}
+
+	t.Run("No encryption", func(t *testing.T) {
+		defer clear()
+
+		assert := assert.New(t)
+
+		cnf := bs.DiskStorageConfig{
+			DataFolder:          dataFolder,
+			ResizedImagesFolder: resizedImagesFolder,
+			Encrypt:             false,
+		}
+		storage, err := bs.NewDiskStorage(cnf)
+		if !assert.Nil(err) {
+			assert.FailNow("can't create a new DiskStorage")
+		}
+
+		generateAndRunTests(assert, storage)
+	})
+
+	t.Run("With encryption", func(t *testing.T) {
+		defer clear()
+
+		assert := assert.New(t)
+
+		cnf := bs.DiskStorageConfig{
+			DataFolder:          dataFolder,
+			ResizedImagesFolder: resizedImagesFolder,
+			Encrypt:             true,
+			PassPhrase:          generatePassPhrase(),
+		}
+		storage, err := bs.NewDiskStorage(cnf)
+		if !assert.Nil(err) {
+			t.FailNow()
+		}
+
+		generateAndRunTests(assert, storage)
+	})
+}
+
+func TestDiskStorage_DeleteFile(t *testing.T) {
+	assert := assert.New(t)
+
+	storage, err := bs.NewDiskStorage(bs.DiskStorageConfig{
+		DataFolder:          dataFolder,
+		ResizedImagesFolder: resizedImagesFolder,
+		Encrypt:             false,
+	})
+	if !assert.Nil(err) {
+		assert.FailNow("can't create a new DiskStorage")
+	}
+
+	defer clear()
+
+	tests := []struct {
+		id         int
+		resized    bool
+		data       []byte
+		fileExists bool
+	}{
+		// Files exist
+		{id: 0, resized: false, data: generateRandomData(512), fileExists: true},
+		{id: 0, resized: true, data: generateRandomData(128), fileExists: true},
+	}
+
+	// Create files
+	for i, tt := range tests {
+		if !tt.fileExists {
+			continue
+		}
+
+		cp := make([]byte, len(tt.data))
+		copy(cp, tt.data)
+
+		buff := bytes.NewBuffer(cp)
+		err := storage.SaveFile(buff, tt.id, tt.resized)
+		if !assert.Nilf(err, "Test #%d: can't create a file", i) {
+			assert.FailNow("can't create a file. Fail now")
+		}
+	}
+
+	// Delete files
+	for i, tt := range tests {
+		err := storage.DeleteFile(tt.id, tt.resized)
+		assert.Nilf(err, "Test #%d: can't delete file", i)
+	}
+}
+
+// clear removes test folders
+func clear() {
+	os.RemoveAll(testFolder)
+}
+
+// Check file compares data of file with passed path and byte slice
+func checkFile(path string, original []byte, encrypt bool, passPhrase []byte) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	if !encrypt {
+		data, err := ioutil.ReadAll(f)
+		if err != nil {
+			return false
+		}
+		return bytes.Equal(original, data)
+	}
+
+	buff := &bytes.Buffer{}
+	_, err = sio.Decrypt(buff, f, sio.Config{Key: passPhrase})
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(original, buff.Bytes())
+}
+
+func generateRandomData(n int) []byte {
+	b := make([]byte, n)
+	rand.Read(b)
+	return b
+}
+
+func generatePassPhrase() [32]byte {
+	slice := generateRandomData(32)
+	var array [32]byte
+	for i := 0; i < 32; i++ {
+		array[i] = slice[i]
+	}
+	return array
+}

--- a/internal/storage/files/files.go
+++ b/internal/storage/files/files.go
@@ -5,15 +5,12 @@ import (
 	"bytes"
 	"io"
 	"mime/multipart"
-	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
 	clog "github.com/ShoshinNikita/log/v2"
-	"github.com/minio/sio"
 	"github.com/pkg/errors"
 
 	"github.com/tags-drive/core/internal/storage/files/aggregation"
@@ -41,43 +38,42 @@ type FileStorage struct {
 	config Config
 
 	metaStorage metadataStorage
+	binStorage  binaryStorage
 	logger      *clog.Logger
 }
 
 // NewFileStorage creates new FileStorage
 func NewFileStorage(cnf Config, lg *clog.Logger) (*FileStorage, error) {
-	// Create folders
-	err := os.MkdirAll(cnf.DataFolder, 0666)
-	if err != nil {
-		return nil, errors.Wrapf(err, "can't create a folder %s", cnf.DataFolder)
-	}
+	var (
+		ms metadataStorage
+		bs binaryStorage
+	)
 
-	err = os.MkdirAll(cnf.ResizedImagesFolder, 0666)
-	if err != nil {
-		return nil, errors.Wrapf(err, "can't create a folder %s", cnf.ResizedImagesFolder)
-	}
-
-	var st metadataStorage
-
+	// Init metadata storage
 	switch cnf.StorageType {
 	case "json":
 		fallthrough
 	default:
-		st = newJsonFileStorage(cnf, lg)
+		ms = newJsonFileStorage(cnf, lg)
+		if err := ms.init(); err != nil {
+			return nil, errors.Wrap(err, "can't init a new Metadata Storage")
+		}
 	}
 
-	fs := &FileStorage{
+	// Init binary storage
+	//
+	// Switch if for future use
+	switch {
+	default:
+		bs = binaryStorageMock{}
+	}
+
+	return &FileStorage{
 		config:      cnf,
-		metaStorage: st,
+		metaStorage: ms,
+		binStorage:  bs,
 		logger:      lg,
-	}
-
-	err = fs.metaStorage.init()
-	if err != nil {
-		return nil, errors.Wrapf(err, "can't init files storage")
-	}
-
-	return fs, nil
+	}, nil
 }
 
 // StartBackgroundJobs starts all background services
@@ -134,26 +130,7 @@ func (fs FileStorage) GetFile(id int) (File, error) {
 
 // CopyFile copies files from disk or another storage to a passed io.Writer
 func (fs FileStorage) CopyFile(w io.Writer, fileID int, resizedImage bool) error {
-	path := fs.config.DataFolder + "/" + strconv.Itoa(fileID)
-	if resizedImage {
-		path = fs.config.ResizedImagesFolder + "/" + strconv.Itoa(fileID)
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	copier := io.Copy
-	if fs.config.Encrypt {
-		copier = func(dst io.Writer, src io.Reader) (int64, error) {
-			return sio.Decrypt(dst, src, sio.Config{Key: fs.config.PassPhrase[:]})
-		}
-	}
-
-	_, err = copier(w, f)
-	return err
+	return fs.binStorage.GetFile(w, fileID, resizedImage)
 }
 
 // CheckFile checks if file with passed id exists
@@ -189,13 +166,9 @@ func (fs FileStorage) Archive(ids []int) (body io.Reader, err error) {
 			continue
 		}
 
-		path := fs.config.DataFolder + "/" + strconv.FormatInt(int64(id), 10)
-		f, err := os.Open(path)
-		if err != nil {
-			fs.logger.Errorf("can't load file \"%s\"\n", fileInfo.Filename)
-			continue
-		}
-		stat, err := f.Stat()
+		// Get stats and create a header
+
+		stat, err := fs.binStorage.GetFileStats(id)
 		if err != nil {
 			fs.logger.Errorf("can't load file \"%s\"\n", fileInfo.Filename)
 			continue
@@ -208,21 +181,14 @@ func (fs FileStorage) Archive(ids []int) (body io.Reader, err error) {
 		wr, err := zipWriter.CreateHeader(header)
 		if err != nil {
 			fs.logger.Errorf("can't load file \"%s\"\n", fileInfo.Filename)
-			f.Close()
 			continue
 		}
 
-		if fs.config.Encrypt {
-			_, err = sio.Decrypt(wr, f, sio.Config{Key: fs.config.PassPhrase[:]})
-		} else {
-			_, err = io.Copy(wr, f)
-		}
-
+		err = fs.binStorage.GetFile(wr, id, false)
 		if err != nil {
 			fs.logger.Errorf("can't load file \"%s\"\n", fileInfo.Filename)
+			continue
 		}
-
-		f.Close()
 	}
 
 	return buff, nil
@@ -261,8 +227,6 @@ func (fs FileStorage) Upload(f *multipart.FileHeader, tags []int) (err error) {
 		}
 	}()
 
-	originPath := fs.config.DataFolder + "/" + strconv.FormatInt(int64(newFileID), 10)
-
 	// Save file
 	switch fileType.FileType {
 	case extensions.FileTypeImage:
@@ -271,15 +235,15 @@ func (fs FileStorage) Upload(f *multipart.FileHeader, tags []int) (err error) {
 		fileReader := io.TeeReader(file, imageReader)
 
 		// Save an original image
-		err = fs.copyToFile(fileReader, originPath)
+		err = fs.binStorage.SaveFile(fileReader, newFileID, false)
 		if err != nil {
+			// Panic will be recovered
 			panic(err)
 		}
 
 		// After saving the original file we can ignore errors and only log them.
 
 		// Convert imageReader into image.Image
-		previewPath := fs.config.ResizedImagesFolder + "/" + strconv.Itoa(newFileID)
 		img, err := resizing.Decode(imageReader)
 		if err != nil {
 			fs.logger.Errorf("can't decode an image %s: %s\n", f.Filename, err)
@@ -293,14 +257,15 @@ func (fs FileStorage) Upload(f *multipart.FileHeader, tags []int) (err error) {
 			fs.logger.Errorf("can't encode a resized image %s: %s\n", f.Filename, err)
 			break
 		}
-		err = fs.copyToFile(r, previewPath)
+		fs.binStorage.SaveFile(r, newFileID, true)
 		if err != nil {
 			fs.logger.Errorf("can't save a resized image %s: %s\n", f.Filename, err)
 		}
 	default:
 		// Save a file
-		err := fs.copyToFile(file, originPath)
+		err = fs.binStorage.SaveFile(file, newFileID, false)
 		if err != nil {
+			// Panic will be recovered
 			panic(err)
 		}
 	}
@@ -310,32 +275,6 @@ func (fs FileStorage) Upload(f *multipart.FileHeader, tags []int) (err error) {
 	// when there are a lot of Upload() calls. Calling runtime.GC() can
 	// decrease max memory usage by 1.5 times with very small performance drop.
 	runtime.GC()
-
-	return nil
-}
-
-// copyToFile copies data from src to new created file
-func (fs FileStorage) copyToFile(src io.Reader, path string) error {
-	// We trunc file, if it already exists
-	newFile, err := os.Create(path)
-	if err != nil {
-		return errors.Wrap(err, "can't create a new file")
-	}
-
-	// Write file
-	if fs.config.Encrypt {
-		_, err = sio.Encrypt(newFile, src, sio.Config{Key: fs.config.PassPhrase[:]})
-	} else {
-		_, err = io.Copy(newFile, src)
-	}
-
-	newFile.Close()
-
-	if err != nil {
-		// Deleting of the bad file
-		os.Remove(path)
-		return errors.Wrap(err, "can't copy a new file")
-	}
 
 	return nil
 }
@@ -383,25 +322,26 @@ func (fs FileStorage) DeleteForce(id int) error {
 		return err
 	}
 
+	var errMsg string
 	// Delete the original file
-	filepath := fs.config.DataFolder + "/" + strconv.Itoa(file.ID)
-	err = os.Remove(filepath)
+	err = fs.binStorage.DeleteFile(file.ID, false)
 	if err != nil {
-		return err
+		errMsg = "can't delete the original file (id is '%d')"
 	}
 
 	if file.Preview != "" {
 		// Delete the resized image
-
-		filepath = fs.config.ResizedImagesFolder + "/" + strconv.Itoa(file.ID)
-		err = os.Remove(filepath)
-		if err != nil {
-			// Only log error
-			fs.logger.Errorf("can't delete a resized image %s: %s\n", file.Filename, err)
+		err1 := fs.binStorage.DeleteFile(file.ID, true)
+		if err1 != nil && err != nil {
+			// Can't delete both files
+			errMsg = "can't delete the original file and the resized image (id is '%d')"
+		} else if err1 != nil {
+			errMsg = "can't delete the resized image (id is '%d')"
+			err = err1
 		}
 	}
 
-	return nil
+	return errors.Wrapf(err, errMsg, file.ID)
 }
 
 // AddTagsToFiles adds a tag to files

--- a/internal/storage/files/types.go
+++ b/internal/storage/files/types.go
@@ -1,8 +1,11 @@
 package files
 
 import (
+	"io"
+	"os"
 	"time"
 
+	"errors"
 	"github.com/tags-drive/core/internal/storage/files/aggregation"
 	"github.com/tags-drive/core/internal/storage/files/extensions"
 )
@@ -62,7 +65,7 @@ const (
 	SortBySizeDecs
 )
 
-// storage is an internal storage for files metadata
+// metadataStorage is a storage for the files metadata
 type metadataStorage interface {
 	init() error
 
@@ -115,3 +118,24 @@ type metadataStorage interface {
 
 	shutdown() error
 }
+
+// binaryStorage is a storage for the files themselves
+type binaryStorage interface {
+	// GetFile writes a file into passed io.Writer
+	GetFile(w io.Writer, fileID int, resized bool) error
+
+	GetFileStats(fileID int) (os.FileInfo, error)
+
+	SaveFile(r io.Reader, fileID int, resized bool) error
+
+	DeleteFile(fileID int, resized bool) error
+}
+
+type binaryStorageMock struct{}
+
+var mockError = errors.New("mock storage is used")
+
+func (_ binaryStorageMock) GetFile(w io.Writer, fileID int, resized bool) error  { return mockError }
+func (_ binaryStorageMock) GetFileStats(fileID int) (os.FileInfo, error)         { return nil, mockError }
+func (_ binaryStorageMock) SaveFile(r io.Reader, fileID int, resized bool) error { return mockError }
+func (_ binaryStorageMock) DeleteFile(fileID int, resized bool) error            { return mockError }


### PR DESCRIPTION
Add package `storage/files/binary_storage`. It provides some ways to keep files themselves (on a disk, in cloud (in future) and etc.)

This PR refactor code for the resolving of issue #80 